### PR TITLE
Replicate ATT across duplicated sprites

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,12 @@ group = "com.badahori.creatures.plugins.intellij.agenteering"
 version = "2022.03.00"
 
 
+
 val korImagesVersion: String by project
+val creaturesAgentUtilVersion: String by project
+val creaturesSpriteUtilVersion: String by project
+val creaturesCommonCliVersion: String by project
+val creaturesCommonCoreVersion: String by project
 
 repositories {
     mavenLocal()
@@ -35,11 +40,11 @@ repositories {
 
 dependencies {
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2") {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0") {
         excludeKotlin()
     }
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
 //    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
 
@@ -51,11 +56,11 @@ dependencies {
         excludeKotlin()
     }
 
-    implementation("bedalton.creatures:AgentUtil:0.04") {
+    implementation("bedalton.creatures:AgentUtil:$creaturesAgentUtilVersion") {
         excludeKotlin()
     }
 
-    implementation("bedalton.creatures:SpriteUtil:0.03") {
+    implementation("bedalton.creatures:SpriteUtil:$creaturesSpriteUtilVersion") {
         excludeKotlin()
     }
 
@@ -63,11 +68,11 @@ dependencies {
         excludeKotlin()
     }
 
-    implementation("bedalton.creatures:CommonCore:0.03") {
+    implementation("bedalton.creatures:CommonCore:$creaturesCommonCoreVersion") {
         excludeKotlin()
     }
 
-    implementation("bedalton.creatures:CommonCLI:0.03") {
+    implementation("bedalton.creatures:CommonCLI:$creaturesCommonCliVersion") {
         excludeKotlin()
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,11 @@
 org.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=--illegal-access=permit
 
+
+# Creatures
+creaturesAgentUtilVersion=1.0
+creaturesSpriteUtilVersion=1.0
+creaturesCommonCliVersion=1.0
+creaturesCommonCoreVersion=1.0
+
+# Korge
 korImagesVersion=2.2.2

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/actions/ReplicateAttOnC1eToC2e.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/actions/ReplicateAttOnC1eToC2e.kt
@@ -1,0 +1,10 @@
+package com.badahori.creatures.plugins.intellij.agenteering.att.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class ReplicateAttOnC1eToC2eAction(): AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorController.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorController.kt
@@ -50,6 +50,10 @@ internal class AttEditorController(
         set(value) {
             model.lockY = value
         }
+    override val replications: Map<Int, List<Int>>
+        get() = model.getReplications()
+    override val notReplicatedLines: List<Int>
+        get() = model.notReplicatedAtts
 
     val isInitialized: Boolean
         get() = this::mView.isInitialized
@@ -96,6 +100,10 @@ internal class AttEditorController(
      */
     override fun getCurrentPoint(): Int {
         return model.currentPoint
+    }
+
+    override fun getFolded(): List<Int> {
+        return model.getFoldedLines()
     }
 
     /**
@@ -251,7 +259,10 @@ internal interface AttEditorHandler: OnChangePoint, HasSelectedCell {
     val showFooterNotification:(message: String, messageType: MessageType)->Unit
     var lockX: Boolean
     var lockY: Boolean
+    val replications: Map<Int, List<Int>>
+    val notReplicatedLines: List<Int>
     fun getCurrentPoint(): Int
+    fun getFolded(): List<Int>
     fun setCurrentPoint(point: Int)
     fun setVariant(variant: CaosVariant)
     fun setPart(part: Char)

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorModel.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorModel.kt
@@ -473,6 +473,9 @@ internal class AttEditorModel(
     }
 
     fun getFoldedLines(): List<Int> {
+        if (replicateAttsToDuplicateSprites == false) {
+            return emptyList()
+        }
         mFoldedLines?.let {
             return it
         }
@@ -486,6 +489,9 @@ internal class AttEditorModel(
     }
 
     internal fun getReplications(): Map<Int, List<Int>> {
+        if (replicateAttsToDuplicateSprites == false) {
+            return emptyMap()
+        }
         mReplications?.let {
             return it
         }

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorModel.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorModel.kt
@@ -9,14 +9,19 @@ import com.badahori.creatures.plugins.intellij.agenteering.att.parser.AttFileLin
 import com.badahori.creatures.plugins.intellij.agenteering.att.parser.AttFileParser.parse
 import com.badahori.creatures.plugins.intellij.agenteering.caos.lang.CaosScriptFile
 import com.badahori.creatures.plugins.intellij.agenteering.caos.libs.CaosVariant
+import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.CaosProjectSettingsComponent
+import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.CaosProjectSettingsService
 import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.ExplicitVariantFilePropertyPusher
 import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.ImplicitVariantFilePropertyPusher
 import com.badahori.creatures.plugins.intellij.agenteering.indices.BreedPartKey
 import com.badahori.creatures.plugins.intellij.agenteering.indices.BreedPartKey.Companion.fromFileName
+import com.badahori.creatures.plugins.intellij.agenteering.injector.CaosNotifications
 import com.badahori.creatures.plugins.intellij.agenteering.sprites.sprite.SpriteParser
 import com.badahori.creatures.plugins.intellij.agenteering.utils.*
 import com.badahori.creatures.plugins.intellij.agenteering.vfs.CaosVirtualFile
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
@@ -48,12 +53,17 @@ internal class AttEditorModel(
 ) : OnChangePoint, HasSelectedCell, Disposable, VirtualFileListener, DocumentListener {
 
     private var mImages: List<BufferedImage>? = null
+    private var mReplications:  Map<Int, List<Int>>? = null
     private var mVariant: CaosVariant = variant
     internal val variant: CaosVariant get() = mVariant
     private var changedSelf: Boolean = false
     private var disposed: AtomicBoolean = AtomicBoolean(false)
+    private val mNotReplicatedAtts = mutableListOf<Int>()
+    private var mCurrentReplication: List<Int>? = null
 
     private var project: Project? = project
+
+    val notReplicatedAtts: List<Int> get() = mNotReplicatedAtts
 
     var mPart: Char = attFile.name[0].lowercase()
     val part: Char get() = mPart
@@ -114,14 +124,26 @@ internal class AttEditorModel(
             mLockX = false; mLockY = value
         }
 
+    var replicateAttsToDuplicateSprites: Boolean? = CaosProjectSettingsService
+        .getInstance(project)
+        .replicateAttsToDuplicateSprites
 
     val actionId = AtomicInteger(0)
 
     val readonly = attFile is CaosVirtualFile
 
+    private var mFoldedLines: List<Int>? = null
+
     init {
         val psiFile = attFile.getPsiFile(project)
         initDocumentListeners(project, psiFile)
+        CaosProjectSettingsComponent.addSettingsChangedListener(this) { _, it ->
+            replicateAttsToDuplicateSprites = it.replicateAttToDuplicateSprite
+            mFoldedLines = null
+            ApplicationManager.getApplication().invokeLater {
+                attChangeListener?.onAttUpdate()
+            }
+        }
         update(variant, part)
     }
 
@@ -302,8 +324,34 @@ internal class AttEditorModel(
         if (attData.toFileText(variant) == text) {
 //            return
         }
+        val oldLines = attData.lines
+        val newData = parse(text, mLinesCount, mPointsCount, fileName = fileName)
+        val newLines = newData.lines.toMutableList()
+        val maxCheck = minOf(newLines.size, oldLines.size)
+        val changed = (0 until maxCheck).filter { i ->
+            oldLines[i] != newLines[i]
+        }
+        val changedLineNumber  = if (changed.size == 1) {
+            changed[0]
+        } else {
+            null
+        }
+//        if (changedLineNumber != null && replicateAttsToDuplicateSprites != false) {
+//            val changedLine = newLines[changedLineNumber]
+//            val replications = getReplications(changedLineNumber)
+//                .filter { it !in independent }
+//            for (replicant in replications) {
+//                newLines[replicant] = changedLine
+//            }
+//        }
+
         // Parse the file data and set it to the ATT instance data
-        mAttData = parse(text, mLinesCount, mPointsCount, fileName = fileName)
+        mAttData = AttFileData(newLines, fileName = fileName)
+
+        if (changedLineNumber != null && mSelectedCell != changedLineNumber) {
+            val changedLine = changed[0]
+            setSelected(changedLine)
+        }
 
         ApplicationManager.getApplication().invokeLater {
             attChangeListener?.onAttUpdate()
@@ -358,23 +406,27 @@ internal class AttEditorModel(
         val data = getEnsuringLines(lineNumber)
         val oldPoints = data.lines[lineNumber].points
         val newPoints: MutableList<Pair<Int, Int>> = ArrayList()
-        var changedPoint = newPoint
-        for (i in oldPoints.indices) {
-            if (currentPoint == i) {
-                if (lockY) {
-                    changedPoint = Pair(newPoint.first, oldPoints[i].second)
-                }
-                if (lockX) {
-                    changedPoint = Pair(oldPoints[i].first, newPoint.second)
-                }
+        val changedPoint = oldPoints.getOrNull(currentPoint)?.let { oldPoint ->
+            if (lockX && lockY) {
+                oldPoint
+            } else if (lockX) {
+                Pair(oldPoint.first, newPoint.second)
+            } else if (lockY) {
+                Pair(newPoint.first, oldPoint.second)
+            } else {
+                newPoint
             }
+        } ?: newPoint
+
+        val currentReplication = currentReplication
+        for (i in oldPoints.indices) {
             newPoints.add(if (i == currentPoint) changedPoint else oldPoints[i])
         }
         val newLine = AttFileLine(newPoints.subList(0, pointsCount))
         val oldLines: List<AttFileLine> = data.lines
         val newLines: MutableList<AttFileLine> = ArrayList()
         for (i in oldLines.indices) {
-            newLines.add(if (i == lineNumber) newLine else oldLines[i])
+            newLines.add(if (i == lineNumber || i in currentReplication) newLine else oldLines[i])
         }
         setAttData(AttFileData(newLines, attFile.name))
     }
@@ -415,9 +467,94 @@ internal class AttEditorModel(
     internal fun reloadFiles() {
         mImages = null
         getImages()
+        mReplications = null
+        getReplications()
         showNotification("Reloaded ATT data", MessageType.INFO)
     }
 
+    fun getFoldedLines(): List<Int> {
+        mFoldedLines?.let {
+            return it
+        }
+        val replications = getReplications()
+        val folded = (0 until linesCount)
+            .filter { i ->
+                i != 0 && replications[i - 1]?.contains(i) == true
+            }
+        mFoldedLines = folded
+        return folded
+    }
+
+    internal fun getReplications(): Map<Int, List<Int>> {
+        mReplications?.let {
+            return it
+        }
+        val images = getImages()
+        val map = mutableMapOf<Int, List<Int>>()
+        for(i in images.indices) {
+            val image = images[i]
+                ?: continue
+            val matches = mutableListOf<Int>()
+            for (j in images.indices) {
+                if (i in mNotReplicatedAtts) {
+                    map[i] = emptyList()
+                    continue
+                }
+                val anImage = images[j]
+                    ?: continue
+                if (j !in mNotReplicatedAtts && i != j && image.contentsEqual(anImage)) {
+                    matches.add(j)
+                }
+            }
+            map[i] = matches
+        }
+        mReplications = map
+        return map
+    }
+
+    private val currentReplication: List<Int> get() {
+        mCurrentReplication?.let {
+            return it
+        }
+
+        val replications = getReplications(mSelectedCell)
+        mCurrentReplication = replications
+        val project = project
+        if (project != null && replicateAttsToDuplicateSprites == null && replications.isNotEmpty()) {
+            CaosProjectSettingsService.getInstance(project).replicateAttsToDuplicateSprites = true
+            showReplicationNotice(project)
+        }
+        return replications
+    }
+
+    private fun getReplications(line: Int): List<Int> {
+        return if (replicateAttsToDuplicateSprites == false || mNotReplicatedAtts.contains(line)) {
+            emptyList()
+        } else {
+            getReplications()[line] ?: emptyList()
+        }
+    }
+
+
+    private fun showReplicationNotice(project: Project) {
+        CaosNotifications.createInfoNotification(
+            project,
+            "ATT Point Replication",
+            "<b>Sprite contains duplicate frames</b>. Att changes in the visual editor will be replicated<br />" +
+                    "NOTE: Manual text changes will not be replicated<br/>" +
+                    "You can change this setting in the CAOS settings panel"
+        ).addAction(object: AnAction("Disable Replication?") {
+            override fun update(e: AnActionEvent) {
+                super.update(e)
+                e.presentation.description = "Disabled ATT point replication in this and future ATT files.\n" +
+                        "Setting can be changed later in the CAOS and Agenteering settings panel"
+            }
+            override fun actionPerformed(e: AnActionEvent) {
+                CaosProjectSettingsService.getInstance(project).replicateAttsToDuplicateSprites = false
+            }
+        })
+            .show()
+    }
 
     fun commit() {
         ApplicationManager.getApplication().invokeLater {
@@ -567,7 +704,37 @@ internal class AttEditorModel(
         if (index >= attData.lines.size) {
             return
         }
-        mSelectedCell = index
+        val progressedIndex = if (replicateAttsToDuplicateSprites != false) {
+            getNotFoldedLine(index)
+        } else {
+            index
+        }
+        mCurrentReplication = null
+        mSelectedCell = progressedIndex
+    }
+
+    /**
+     * Get the cell that is not currently folded, or itself if cannot find a not folded cell
+     */
+    private fun getNotFoldedLine(newIndex: Int): Int {
+        if (newIndex == mSelectedCell) {
+            return newIndex
+        }
+        val replications = getReplications()
+        var keys = replications
+            .keys
+            .toList()
+        keys = if (mSelectedCell < newIndex) {
+            keys.sorted()
+        } else {
+            keys.sortedDescending()
+        }
+        return keys
+            .firstOrNull { i ->
+                replications[i]?.contains(newIndex) == true
+            }
+            ?: newIndex
+
     }
 
     override fun dispose() {

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
@@ -5,6 +5,7 @@ import com.badahori.creatures.plugins.intellij.agenteering.att.editor.pose.PoseE
 import com.badahori.creatures.plugins.intellij.agenteering.att.parser.AttFileData;
 import com.badahori.creatures.plugins.intellij.agenteering.att.parser.AttFileLine;
 import com.badahori.creatures.plugins.intellij.agenteering.caos.libs.CaosVariant;
+import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.CaosProjectSettingsComponent;
 import com.badahori.creatures.plugins.intellij.agenteering.caos.settings.CaosProjectSettingsService;
 import com.badahori.creatures.plugins.intellij.agenteering.indices.BodyPartFiles;
 import com.badahori.creatures.plugins.intellij.agenteering.indices.BreedPartKey;
@@ -100,6 +101,10 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         (new RuntimeException()).printStackTrace();
         poseEditor.setRootPath(controller.getRootPath());
         updateUI();
+        CaosProjectSettingsComponent.addSettingsChangedListener((old, settings) -> {
+            LOGGER.info("Updated project settings");
+            updateCells();
+        });
     }
 
     private void initListeners() {
@@ -698,7 +703,7 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
                 maxHeight = image.getHeight();
             }
             // Adds this point and image to the list
-            out.add(new AttSpriteCellData(i, image, lines.get(i).getPoints(), pointNames, controller, this));
+            out.add(new AttSpriteCellData(i, image, lines.get(i).getPoints(), pointNames, controller.getFolded(), controller, this));
         }
         spriteCellList.setMaxWidth(maxWidth);
         spriteCellList.setMaxHeight(maxHeight);

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
@@ -60,6 +60,9 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
     private boolean didInit = false;
     private final AttEditorHandler controller;
 
+    // Pose has recently changed, so re-render
+    private boolean poseChanged = false;
+
     protected JButton refreshButton;
     private final CaosProjectSettingsService settings;
 
@@ -96,9 +99,6 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         initListeners();
         initPopupMenu();
         initDisplay(controller.getVariant());
-//        poseEditor.init();
-
-        (new RuntimeException()).printStackTrace();
         poseEditor.setRootPath(controller.getRootPath());
         updateUI();
         CaosProjectSettingsComponent.addSettingsChangedListener((old, settings) -> {
@@ -396,16 +396,6 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         labels.setSelected(settings.getShowLabels());
         poseEditor.setRootPath(controller.getRootPath());
         pushAttToPoseEditor(controller.getAttData());
-        final Pose pose = controller.getPose();
-        controller.setPose(null);
-        if (pose != null && (getVariant().isNotOld() || pose.getBody() < 8)) {
-            try {
-                poseEditor.setPose(pose, true);
-            } catch (Exception e) {
-                LOGGER.severe("Failed to set pose during init");
-                e.printStackTrace();
-            }
-        }
         didLoadOnce = true;
 
         // Select defaults
@@ -424,10 +414,11 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         poseViewCheckbox.setSelected(showPoseView);
         showPoseView(showPoseView);
 
+        poseEditor.setAtt(controller.getPart(), controller.getSpriteFile(), controller.getAttData());
 
         loadRequestedPose();
-        poseEditor.setAtt(controller.getPart(), controller.getSpriteFile(), controller.getAttData());
     }
+
 
     private void pushAttToPoseEditor(final AttFileData attFile) {
         if (this.controller.getPart() == 'z') {
@@ -823,7 +814,7 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         if (didLoadOnce) {
             controller.setPose(null);
         }
-        poseEditor.setPose(requestedPose, true);
+        poseEditor.setNextPose(requestedPose);
         final Integer pose = requestedPose.get(getPart());
         if (pose != null) {
             setSelected(pose);

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttEditorPanel.java
@@ -102,7 +102,6 @@ public class AttEditorPanel implements HasSelectedCell, AttEditorController.View
         poseEditor.setRootPath(controller.getRootPath());
         updateUI();
         CaosProjectSettingsComponent.addSettingsChangedListener((old, settings) -> {
-            LOGGER.info("Updated project settings");
             updateCells();
         });
     }

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttSpriteCellRenderer.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttSpriteCellRenderer.kt
@@ -4,6 +4,7 @@ import com.badahori.creatures.plugins.intellij.agenteering.utils.LOGGER
 import com.badahori.creatures.plugins.intellij.agenteering.utils.height
 import com.badahori.creatures.plugins.intellij.agenteering.utils.width
 import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.ui.JBColor
 import java.awt.*
 import java.awt.event.*
 import java.awt.image.BufferedImage
@@ -118,7 +119,7 @@ internal class AttSpriteCellComponent : JPanel() {
                 this.foldedLabel = foldLabel
                 add(foldLabel)
             }
-            foldLabel.foreground = Color(255,255,255,120)
+            foldLabel.foreground = REPLICATED_MESSAGE_FONT_COLOR
             foldLabel.text = "  Duplicate image. Points are being replicated from cell above"
             foldLabel.isVisible = true
             width = maxOf(foldLabel.width, 10)
@@ -293,6 +294,11 @@ internal class AttSpriteCellComponent : JPanel() {
     }
 
     companion object {
+
+        private val REPLICATED_MESSAGE_FONT_COLOR = JBColor(
+            Color(30, 30, 30, 120),
+            Color(220, 220, 220, 127)
+        )
         fun scalePoints(points: List<Pair<Int,Int>>, scale: Double): List<Pair<Int,Int>> {
             return points.subList(0, minOf(6, points.size)).map {
                 Pair(floor(it.first * scale).toInt(), floor(it.second * scale).toInt())

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttSpriteCellRenderer.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/AttSpriteCellRenderer.kt
@@ -1,13 +1,13 @@
 package com.badahori.creatures.plugins.intellij.agenteering.att.editor
 
 import com.badahori.creatures.plugins.intellij.agenteering.utils.LOGGER
-import com.badahori.creatures.plugins.intellij.agenteering.utils.invokeLater
-import com.badahori.creatures.plugins.intellij.agenteering.utils.orTrue
+import com.badahori.creatures.plugins.intellij.agenteering.utils.height
+import com.badahori.creatures.plugins.intellij.agenteering.utils.width
 import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.soywiz.korma.math.min
 import java.awt.*
 import java.awt.event.*
 import java.awt.image.BufferedImage
+import java.awt.image.ImageObserver
 import javax.swing.*
 import kotlin.math.floor
 
@@ -27,9 +27,12 @@ data class AttSpriteCellData(
     val image: BufferedImage,
     val points: List<Pair<Int, Int>>,
     val pointNames: List<String>,
+    val folded: List<Int>,
     private val changePointListener: OnChangePoint,
     private val changeCellListener: HasSelectedCell,
 ) {
+    val isFolded: Boolean get() = index in folded
+
     val isFocused: Boolean get() = changeCellListener.selectedCell == index
     fun onPlace(point: Pair<Int, Int>) {
         if (changeCellListener.selectedCell == index)
@@ -44,6 +47,18 @@ data class AttSpriteCellData(
         }
     }
 
+    fun focusPreviousCell() {
+        if (index > 0) {
+            changeCellListener.setSelected(index - 1)
+        }
+    }
+
+    fun focusNextCell() {
+        if (index < 16) {
+            changeCellListener.setSelected(index + 1)
+        }
+    }
+
     fun shiftPoint(xDelta: Int, yDelta: Int) {
         changePointListener.onShiftPoint(index, Pair(xDelta, yDelta))
     }
@@ -52,88 +67,142 @@ data class AttSpriteCellData(
 
 
 internal class AttSpriteCellComponent : JPanel() {
+
+    private var data: AttSpriteCellData? = null
+    private var indexLabel: JLabel = JLabel("")
+        .apply { inheritsPopupMenu = true }
+    private var canvas: AttCellCanvas? = null
+    private var foldedLabel: JLabel? = null
+    private var padding: Component? = null
+    private val isFolded: Boolean get() = data?.isFolded == true
+
     init {
         this.layout = BoxLayout(this, BoxLayout.X_AXIS)
         this.border = BorderFactory.createEmptyBorder(5, 16, 10, 5)
         inheritsPopupMenu = true
         this.isFocusable = true
+        this.add(indexLabel)
+        bindKeyboardShortcuts()
     }
 
     internal fun update(labels: Boolean, scale: Double, value: AttSpriteCellData, selected: Boolean) {
-        removeAll()
-        this.add(JLabel("${value.index + 1}.").apply { inheritsPopupMenu = true })
+        // Set index label to this index
+        indexLabel.text = "${value.index + 1}."
+
+        // Set the current data for use by handlers
+        this.data = value
+        this.removeAll()
+        this.add(indexLabel)
+
+        // Scale image if needed
         val imageValue = value.image
-        val width = imageValue.width * scale
-        val height = imageValue.height * scale
-        val image = if (width > 0 && height > 0) {
+        val folded = isFolded
+        var width = if (folded) -1 else (imageValue.width * scale).toInt()
+        var height = if (folded) -1 else (imageValue.height * scale).toInt()
+        val image: Image = if (width > 0 && height > 0) {
             imageValue.getScaledInstance(
-                width.toInt(),
-                height.toInt(),
+                width,
+                height,
                 Image.SCALE_AREA_AVERAGING
             ) // scale it the smooth way
         } else {
             imageValue
         }
 
-        val scaledPoints: List<Pair<Int, Int>> = value.points.subList(0, minOf(6, value.points.size)).map {
-            Pair(floor(it.first * scale).toInt(), floor(it.second * scale).toInt())
+
+        // If folded, show folded label only
+        if (folded) {
+            var foldLabel: JLabel? = this.foldedLabel
+            if (foldLabel == null) {
+                foldLabel = JLabel()
+                this.foldedLabel = foldLabel
+                add(foldLabel)
+            }
+            foldLabel.foreground = Color(255,255,255,120)
+            foldLabel.text = "  Duplicate image. Points are being replicated from cell above"
+            foldLabel.isVisible = true
+            width = maxOf(foldLabel.width, 10)
+            height = maxOf(foldLabel.height, 160)
+            this.add(foldLabel)
+            foldLabel.alignmentX = Component.LEFT_ALIGNMENT
+            this.add(Box.createHorizontalGlue())
+            foldLabel.minimumSize = Dimension(100, 20)
+        } else {
+            // If not folded, update canvas
+            val canvas = getCanvas(image)
+            canvas.selected = selected
+            canvas.image
+            canvas.labels = labels
+            canvas.pointNames = value.pointNames
+            canvas.scaledPoints = scalePoints(value.points, scale)
+            canvas.scale = scale
+            canvas.pointNames = value.pointNames
+            canvas.isVisible = true
+            canvas.revalidate()
+            this.add(canvas)
+            canvas.alignmentX = Component.LEFT_ALIGNMENT
         }
 
-        val canvas = object : JPanel() {
-            var scaledFont: Font? = null
-            override fun paintComponent(g: Graphics) {
-                super.paintComponent(g)
-                g.drawImage(image, 0, 0, this)
-                if (!selected) {
-                    g.color = Color(0, 0, 0, 60)
-                    g.fillRect(0, 0, width.toInt(), height.toInt())
-                    g.color = Color(255, 255, 255, 255)
-                    g.drawCenteredString("Click to Edit", Rectangle(0, 0, width.toInt(), height.toInt()))
-                }
-                val g2 = g as Graphics2D
-                if (selected) {
-                    scaledPoints.forEachIndexed { index, point ->
-                        val label: String = if (labels)
-                            value.pointNames.getOrNull(index)?.let { name -> "${index + 1}: $name" } ?: "Point $index"
-                        else
-                            "${index + 1}"
-                        g2.color = colors[index]
-                        if (scaledFont == null)
-                            scaledFont = g2.font.deriveFont(8)
-                        g2.font = scaledFont!!
-                        g2.drawString(label, point.first + 4, point.second + 4)
-                    }
-                    g2.stroke = BasicStroke(maxOf(0.8f * scale.toFloat(), 2.0f))
-                    scaledPoints.forEachIndexed { index, point ->
-                        g2.color = colors[index]
-                        g2.drawLine(point.first, point.second, point.first, point.second)
-                    }
-                }
-            }
-        }.apply {
-            val imageDimension = Dimension(width.toInt() + 50, height.toInt() + 40)
-            size = imageDimension
-            preferredSize = imageDimension
-            minimumSize = imageDimension
-            background = Color.BLACK
-        }
-        val dimension = Dimension(width.toInt() + 120, height.toInt() + 40)
-        this.size = dimension
-        this.preferredSize = dimension
+        // Set sizing information
+        val padWidth = if (folded) 0 else 120
+        val padHeight = if (folded) 0 else 40
+        val dimension = Dimension(width + padWidth, height + padHeight)
+//        this.size = dimension
+//        this.preferredSize = dimension
         this.minimumSize = dimension
 
-        isFocusable = true
+        // Redraw
+        revalidate()
+        repaint()
+        if (selected) {
+            requestFocus()
+        }
+    }
+
+
+    private fun getCanvas(image: Image): AttCellCanvas {
+        canvas?.let {
+            return it
+        }
+        val canvas = AttCellCanvas(
+            false,
+            image,
+            emptyList(),
+            false,
+            emptyList(),
+            1.0
+        )
+        add(canvas)
+        canvas.alignmentX = Component.LEFT_ALIGNMENT
+        initMouseListeners(canvas)
+        this.canvas = canvas
+        canvas.isFocusable = true
+        canvas.inheritsPopupMenu = true
+        this.canvas = canvas
+        return canvas
+    }
+
+    private fun initMouseListeners(canvas: AttCellCanvas) {
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
+                if (isFolded) {
+                    return
+                }
                 super.mouseClicked(e)
                 if (e.button == MouseEvent.BUTTON1) {
-                    value.onFocus()
+                    data?.onFocus()
                 }
             }
         })
+
         canvas.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
+                if (isFolded) {
+                    return
+                }
                 super.mouseClicked(e)
+                val data = data
+                    ?: return
                 if (e.source !== canvas) {
                     return
                 }
@@ -142,58 +211,76 @@ internal class AttSpriteCellComponent : JPanel() {
                     return
                 }
                 if (e.button == MouseEvent.BUTTON1) {
-                    val x = (e.x / scale).toInt()
-                    val y = (e.y / scale).toInt()
-
-                    if (imageValue.width < x || imageValue.height < y) {
-                        value.onFocus()
+                    val x = (e.x / canvas.scale).toInt()
+                    val y = (e.y / canvas.scale).toInt()
+                    val image = data.image
+                    if (image.width < x || image.height < y) {
+                        data.onFocus()
                         return
                     }
                     if (x < 0 || y < 0)
                         return
-                    value.onPlace(Pair(x, y))
+                    data.onPlace(Pair(x, y))
                 }
             }
         })
+    }
+
+    private fun bindKeyboardShortcuts() {
 
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.up", KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0)) {
-            value.shiftPoint(0, -1)
+            data?.shiftPoint(0, -1)
         }
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.up", KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, 0)) {
-            value.shiftPoint(0, -1)
+            data?.shiftPoint(0, -1)
         }
+
+        bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.up", KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, 0)) {
+            data?.shiftPoint(0, -1)
+        }
+
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.down", KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0)) {
-            value.shiftPoint(0, 1)
+            data?.shiftPoint(0, 1)
         }
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.down", KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, 0)) {
-            value.shiftPoint(0, 1)
+            data?.shiftPoint(0, 1)
         }
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.right", KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0)) {
-            value.shiftPoint(1, 0)
+            data?.shiftPoint(1, 0)
         }
         bindKeyStroke(
             WHEN_ANCESTOR_OF_FOCUSED_COMPONENT,
             "move.right",
             KeyStroke.getKeyStroke(KeyEvent.VK_KP_RIGHT, 0)
         ) {
-            value.shiftPoint(1, 0)
+            data?.shiftPoint(1, 0)
         }
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.left", KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0)) {
-            value.shiftPoint(-1, 0)
+            data?.shiftPoint(-1, 0)
         }
         bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "move.left", KeyStroke.getKeyStroke(KeyEvent.VK_KP_LEFT, 0)) {
-            value.shiftPoint(-1, 0)
+            data?.shiftPoint(-1, 0)
         }
-        canvas.isFocusable = true
-        canvas.inheritsPopupMenu = true
-        add(canvas)
-        revalidate()
-        repaint()
-        if (selected) {
-            requestFocus()
+
+
+        // Shift Focus up or down
+        bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "focus.previous", KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_DOWN_MASK)) {
+            data?.focusPreviousCell()
+        }
+        // Shift Focus up or down
+        bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "focus.previous", KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, InputEvent.SHIFT_DOWN_MASK)) {
+            data?.focusPreviousCell()
+        }
+
+        bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "focus.next", KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.SHIFT_DOWN_MASK)) {
+            data?.focusNextCell()
+        }
+        bindKeyStroke(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, "focus.next", KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, InputEvent.SHIFT_DOWN_MASK)) {
+            data?.focusNextCell()
         }
     }
 
+    @Suppress("SameParameterValue")
     private fun bindKeyStroke(condition: Int, name: String?, keyStroke: KeyStroke?, action: () -> Unit) {
         val im = getInputMap(condition)
         val am = actionMap
@@ -203,6 +290,14 @@ internal class AttSpriteCellComponent : JPanel() {
                 action()
             }
         })
+    }
+
+    companion object {
+        fun scalePoints(points: List<Pair<Int,Int>>, scale: Double): List<Pair<Int,Int>> {
+            return points.subList(0, minOf(6, points.size)).map {
+                Pair(floor(it.first * scale).toInt(), floor(it.second * scale).toInt())
+            }
+        }
     }
 }
 
@@ -214,7 +309,7 @@ internal class AttSpriteCellList(
     private var scale: Double = 1.0,
     var maxWidth: Int = 300,
     var maxHeight: Int = 300,
-    var labels: Boolean = true
+    var labels: Boolean = true,
 ) : JPanel() {
 
     private val pool: MutableList<AttSpriteCellComponent> = mutableListOf()
@@ -247,8 +342,9 @@ internal class AttSpriteCellList(
         val size = newItems.size
         if (pool.size > size) {
             pool.forEachIndexed { i, component ->
-                if (i < size)
+                if (i < size) {
                     return
+                }
                 component.isVisible = false
             }
         }
@@ -256,7 +352,7 @@ internal class AttSpriteCellList(
     }
 
     init {
-        layout = GridLayout(0, 1)
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
         reload()
     }
 
@@ -273,18 +369,20 @@ internal class AttSpriteCellList(
         panel.update(labels, scale, value, value.isFocused)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun scrollTo(pose: Int) {
-        val item = get(pose)
-        invokeLater later@{
-            (parent as? JPanel)?.doLayout()
-            val bounds = item.bounds
-            val visibleRect = visibleRect
-            if (visibleRect.contains(bounds).orTrue())
-                return@later
-            val offset = visibleRect.intersection(bounds)
-//            (parent?.parent as? JScrollPane)?.verticalScrollBar?.value = offset
-
-        }
+//        TODO: Implement properly without it being frustrating to the end user
+//        val item = get(pose)
+//        invokeLater later@{
+//            (parent as? JPanel)?.doLayout()
+//            val bounds = item.bounds
+//            val visibleRect = visibleRect
+//            if (visibleRect.contains(bounds).orTrue())
+//                return@later
+//            val offset = visibleRect.intersection(bounds)
+////            (parent?.parent as? JScrollPane)?.verticalScrollBar?.value = offset
+//
+//        }
     }
 }
 
@@ -319,4 +417,56 @@ fun Graphics.drawCenteredString(text: String, rect: Rectangle, font: Font? = nul
 
     // Draw the String
     drawString(text, x, y)
+}
+
+
+private class AttCellCanvas(
+    var selected: Boolean,
+    var image: Image,
+    var scaledPoints: List<Pair<Int, Int>>,
+    var labels: Boolean,
+    var pointNames: List<String>,
+    var scale: Double,
+): JPanel() {
+
+    var scaledFont: Font? = null
+
+
+    init {
+        val imageDimension = Dimension(image.width + 50, image.height + 40)
+        size = imageDimension
+        preferredSize = imageDimension
+        minimumSize = imageDimension
+        background = Color.BLACK
+    }
+
+    override fun paintComponent(g: Graphics) {
+        super.paintComponent(g)
+        g.drawImage(image, 0, 0, this)
+        if (!selected) {
+            g.color = Color(0, 0, 0, 60)
+            g.fillRect(0, 0, width, height)
+            g.color = Color(255, 255, 255, 255)
+            g.drawCenteredString("Click to Edit", Rectangle(0, 0, width, height))
+        }
+        val g2 = g as Graphics2D
+        if (selected) {
+            scaledPoints.forEachIndexed { index, point ->
+                val label: String = if (labels)
+                    pointNames.getOrNull(index)?.let { name -> "${index + 1}: $name" } ?: "Point $index"
+                else
+                    "${index + 1}"
+                g2.color = colors[index]
+                if (scaledFont == null)
+                    scaledFont = g2.font.deriveFont(8)
+                g2.font = scaledFont!!
+                g2.drawString(label, point.first + 4, point.second + 4)
+            }
+            g2.stroke = BasicStroke(maxOf(0.8f * scale.toFloat(), 2.0f))
+            scaledPoints.forEachIndexed { index, point ->
+                g2.color = colors[index]
+                g2.drawLine(point.first, point.second, point.first, point.second)
+            }
+        }
+    }
 }

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/pose/PoseEditor.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/pose/PoseEditor.kt
@@ -1,3 +1,0 @@
-package com.badahori.creatures.plugins.intellij.agenteering.att.editor.pose
-
-import com.badahori.creatures.plugins.intellij.agenteering.indices.BodyPartFiles

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/pose/PoseEditorImpl.java
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/att/editor/pose/PoseEditorImpl.java
@@ -1378,7 +1378,6 @@ public class PoseEditorImpl implements Disposable, BreedPoseHolder {
             return;
         }
         headPose.setSelectedIndex(headPoseData.getDirection());
-        LOGGER.info("Setting <Head> pose to " + headPose.getSelectedIndex());
         if (headPoseData.getTilt() != null) {
             if (headPoseData.getTilt() >= 4) {
                 LOGGER.severe("Tilt invalid. Pose: " + pose + "; Data: " + headPoseData);
@@ -1476,9 +1475,6 @@ public class PoseEditorImpl implements Disposable, BreedPoseHolder {
         if (pose >= comboBox.getItemCount()) {
             LOGGER.severe("Part " + charPart + " pose '" + pose + "' is greater than options (" + comboBox.getItemCount() + ")");
             pose = 0;
-        }
-        if (pose != comboBox.getSelectedIndex()) {
-            LOGGER.info("Setting part <" + charPart + "> to " + pose);
         }
         comboBox.setSelectedIndex(pose);
         // Redraw the image

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/bundles/general/get-similar-files.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/bundles/general/get-similar-files.kt
@@ -26,7 +26,8 @@ internal fun getFilenameSuggestions(
     baseFileName: String,
     extensions: List<String>? = null,
     orb: Int = DEFAULT_ORB,
-    includedFiles: List<String>
+    includedFiles: List<String>,
+    pathless: Boolean = false
 ): List<CaosScriptReplaceElementFix>? {
     val fileNameExtension = extensions
         ?: getExtension(baseFileName)
@@ -41,7 +42,8 @@ internal fun getFilenameSuggestions(
         baseFileName,
         extensions = fileNameExtension,
         orb = orb,
-        includedFiles
+        includedFiles,
+        pathless
     )
 }
 
@@ -58,7 +60,8 @@ internal fun getFilenameSuggestions(
     filePath: String,
     extensions: List<String>? = null,
     orb: Int = DEFAULT_ORB,
-    includedFiles: List<String>
+    includedFiles: List<String>,
+    pathless: Boolean = false,
 ): List<CaosScriptReplaceElementFix>? {
 
     val fileName = filePath.split(PATH_SPLIT).last()
@@ -71,9 +74,16 @@ internal fun getFilenameSuggestions(
     val fileNameWithoutExtension = FileNameUtil.getFileNameWithoutExtension(fileName)
         ?: return null
 
-    val ignoredFiles = element.containingFile?.module?.settings?.ignoredFiles.orEmpty() +
+    val ignoredFilesRaw = element.containingFile?.module?.settings?.ignoredFiles.orEmpty() +
             element.project.settings.ignoredFiles +
             includedFiles
+
+
+    val ignoredFiles = if (pathless) {
+        (ignoredFilesRaw + includedFiles.mapNotNull { FileNameUtil.getLastPathComponent(it) }).distinct()
+    } else {
+        ignoredFilesRaw
+    }
 
     if (fileName in ignoredFiles) {
         return null
@@ -112,12 +122,13 @@ internal fun getFilenameSuggestions(
 
     if (ignoredFilename != null) {
         // Is case-insensitive file system
-        if (OsUtil.isWindows)
+        if (OsUtil.isWindows) {
             return null
+        }
 
-        if (removeExtension && FileNameUtil.getFileNameWithoutExtension(ignoredFilename) == fileNameWithoutExtension)
+        if (removeExtension && FileNameUtil.getFileNameWithoutExtension(ignoredFilename) == fileNameWithoutExtension) {
             return null
-
+        }
         // Create single fix array
         return CaosScriptReplaceElementFix(
             element,

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/stubs/CaosScriptStubVersions.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/stubs/CaosScriptStubVersions.kt
@@ -1,5 +1,5 @@
 package com.badahori.creatures.plugins.intellij.agenteering.caos.stubs
 
 private const val MINOR_VERSION:Int = 0
-private const val MAJOR_VERSION:Int = 29
+private const val MAJOR_VERSION:Int = 30
 const val CAOS_SCRIPT_STUB_VERSION = MAJOR_VERSION + MINOR_VERSION;

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/utils/BufferedImageExtensions.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/utils/BufferedImageExtensions.kt
@@ -2,12 +2,11 @@ package com.badahori.creatures.plugins.intellij.agenteering.utils
 
 import org.apache.commons.imaging.palette.Dithering
 import org.apache.commons.imaging.palette.Palette
-import java.awt.Graphics2D
-import java.awt.Image
-import java.awt.Toolkit
+import java.awt.*
 import java.awt.datatransfer.*
 import java.awt.geom.AffineTransform
 import java.awt.image.BufferedImage
+import java.awt.image.ImageObserver
 import java.awt.image.RenderedImage
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
@@ -119,4 +118,53 @@ private class CopyImageToClipBoard : ClipboardOwner {
             return false
         }
     }
+}
+
+
+/**
+ * Compares two images pixel by pixel.
+ * @param otherImage the second image.
+ * @return whether the images are both the same or not.
+ */
+internal fun BufferedImage.contentsEqual(otherImage: BufferedImage): Boolean {
+    // The images must be the same size.
+    if (width != otherImage.width || height != otherImage.height) {
+        return false;
+    }
+
+    val width  = width
+    val height = height
+
+    // Loop over every pixel.
+    repeat (height) { y ->
+        repeat(width) { x ->
+            // Compare the pixels for equality.
+            if (getRGB(x, y) != otherImage.getRGB(x, y)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+
+private val mMediaTracker = MediaTracker(Panel())
+private val mImageObserver = ImageObserver { _, _, _, _, _, _ -> true }
+
+private fun waitForImage(image: Image) {
+    try {
+        mMediaTracker.addImage(image, 0)
+        mMediaTracker.waitForID(0)
+    } finally {
+        mMediaTracker.removeImage(image)
+    }
+}
+val Image.width: Int get() {
+    waitForImage(this)
+    return getWidth(mImageObserver)
+}
+val Image.height: Int get() {
+    waitForImage(this)
+    return getHeight(mImageObserver)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -246,10 +246,13 @@
         implementation="com.badahori.creatures.plugins.intellij.agenteering.caos.project.module.CaosModuleConfigurationEditorProvider" />
 
 
-    <!--    <treeStructureProvider-->
-    <!--        implementation="com.badahori.creatures.plugins.intellij.agenteering.nodes.BreedTreeProvider" />-->
+    <treeStructureProvider
+            implementation="com.badahori.creatures.plugins.intellij.agenteering.nodes.BreedTreeProvider"
+            order="after CaosTreeViewProvider"
+    />
 
     <treeStructureProvider
+        id="CaosTreeViewProvider"
         implementation="com.badahori.creatures.plugins.intellij.agenteering.nodes.CaosTreeViewProvider" />
 
     <projectConfigurable parentId="language"


### PR DESCRIPTION
C1e->C2e breed conversions tend to duplicate the front and back sprites, so this update allows the ATT to be automatically copied across consecutive duplicate sprites