### PR TITLE
Add wine executable select

### DIFF
--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/CaosApplicationSettingsService.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/CaosApplicationSettingsService.kt
@@ -15,6 +15,9 @@ interface CaosApplicationSettingsService:
 {
     var isAutoPoseEnabled: Boolean
     var lastWineDirectory: String?
+    var wine32Path: String?
+    var wine64Path: String?
+    var winePath: String?
     var combineAttNodes: Boolean
     var replicateAttsToDuplicateSprites: Boolean?
     override var ignoredCatalogueTags: List<String>

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/CaosApplicationSettingsState.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/CaosApplicationSettingsState.kt
@@ -34,6 +34,9 @@ class CaosApplicationSettingsState : CaosApplicationSettingsService,
     private var mLastWineDirectory: String? = null
     private var mCombineAttNodes: Boolean = false
     private var mReplicateAttToDuplicateSprite: Boolean? = null
+    private var mWinePath: String? = null
+    private var mWine32Path: String? = null
+    private var mWine64Path: String? = null
 
     @Attribute(converter = StringListConverter::class)
     private var mIgnoredCatalogueTags: List<String> = emptyList()
@@ -142,9 +145,38 @@ class CaosApplicationSettingsState : CaosApplicationSettingsService,
         }
 
     override var gameInterfaceNames: List<GameInterfaceName>
-        get() = mGameInterfaceNames.filterNotNull()
+        get() = mGameInterfaceNames
         set(value) {
-            mGameInterfaceNames = value.filterNotNull()
+            mGameInterfaceNames = value
+            loadState(this)
+        }
+
+    override var winePath: String?
+        get() = mWinePath ?: wine32Path ?: wine64Path
+        set(value) {
+            mWinePath = value
+
+            if (mWine32Path == null) {
+                mWine32Path = value
+            }
+            
+            if (mWine64Path == null) {
+                mWine64Path = value
+            }
+            loadState(this)
+        }
+
+    override var wine32Path: String?
+        get() = mWine32Path
+        set(value) {
+            mWine32Path = value
+            loadState(this)
+        }
+
+    override var wine64Path: String?
+        get() = mWine64Path
+        set(value) {
+            mWine64Path = value
             loadState(this)
         }
 

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/ProjectSettingsPanel.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/caos/settings/ProjectSettingsPanel.kt
@@ -105,6 +105,8 @@ private class ProjectSettingsPanel(
     private val originalDefaultVariant: String = projectSettings.defaultVariant?.code ?: ""
     private val originalIsAutoPoseEnabled: Boolean = applicationSettings.isAutoPoseEnabled
     private val originalTrimBlk: Boolean? = projectSettings.trimBLKs
+    private val originalWine32Path: String? = applicationSettings.wine32Path
+    private val originalWine64Path: String? = applicationSettings.wine64Path
 
     private var mInterfaceNamesAreValid = true
     val interfaceNamesAreValid get() = mInterfaceNamesAreValid
@@ -192,6 +194,14 @@ private class ProjectSettingsPanel(
         }
     }
 
+    val wine32PathTextField by lazy {
+        JTextField(originalWine32Path)
+    }
+
+    val wine64PathTextField by lazy {
+        JTextField(originalWine64Path)
+    }
+
     val panel: JPanel by lazy {
         FormBuilder.createFormBuilder()
             .addLabeledComponent(JLabel("Default Variant"), defaultVariant, 1, false)
@@ -200,6 +210,8 @@ private class ProjectSettingsPanel(
             .addLabeledComponent(JLabel("Trim BLK right and bottom"), trimBlkCheckbox, 1, false)
             .addLabeledComponent(JLabel("Ignored File Names"), ignoredFileNames, 1, true)
             .addLabeledComponent(JLabel("Game Interface Names"), gameInterfaceNames, 1, true)
+            .addLabeledComponent(JLabel("Wine32Path"), wine32PathTextField, 1, false)
+            .addLabeledComponent(JLabel("Wine64Path"), wine64PathTextField, 1, false)
             .addLabeledComponent(JLabel("Enable AutoPose action"), autoPoseCheckbox, 1, false)
             .panel
             .apply {
@@ -232,6 +244,12 @@ private class ProjectSettingsPanel(
         if (trimBlkCheckbox.isSelected != projectSettings.trimBLKs) {
             return true
         }
+        if (wine32PathTextField.text != originalWine32Path) {
+            return true
+        }
+        if (wine64PathTextField.text != originalWine64Path) {
+            return true
+        }
         return false
     }
 
@@ -259,6 +277,8 @@ private class ProjectSettingsPanel(
             this.gameInterfaceNames = gameInterfaceNames
             this.isAutoPoseEnabled = autoPoseCheckbox.isSelected
             this.replicateAttsToDuplicateSprites = this@ProjectSettingsPanel.replicateAttToDuplicateSprites.isSelected
+            this.wine64Path = this@ProjectSettingsPanel.wine64PathTextField.text
+            this.wine32Path = this@ProjectSettingsPanel.wine32PathTextField.text
         }
         applicationSettings = newSettings
         return newSettings
@@ -282,6 +302,8 @@ private class ProjectSettingsPanel(
         combineAttNodes.isSelected = originalCombineAttNodes
         replicateAttToDuplicateSprites.isSelected = originalReplicateAttToDuplicateSprite
         trimBlkCheckbox.isSelected = originalTrimBlk != false
+        wine32PathTextField.text = originalWine32Path
+        wine64PathTextField.text = originalWine64Path
     }
 
     /**

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/C3Connection.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/C3Connection.kt
@@ -50,7 +50,7 @@ internal class C3Connection(override val variant: CaosVariant, private val data:
             }
         }
 
-    override fun injectWithJect(caos: CaosScriptFile, flags: Int): InjectionStatus {
+    override fun injectWithJect(project: Project, caos: CaosScriptFile, flags: Int): InjectionStatus {
         return InjectionStatus.ActionNotSupported(
             caos.name,
             null,
@@ -59,7 +59,12 @@ internal class C3Connection(override val variant: CaosVariant, private val data:
     }
 
     @Suppress("SameParameterValue")
-    override fun inject(fileName: String, descriptor: String?, caos: String): InjectionStatus {
+    override fun inject(
+        project: Project,
+        fileName: String,
+        descriptor: String?,
+        caos: String
+    ): InjectionStatus {
         if (!isWindows) {
             return NOT_WINDOWS_STATUS
         }
@@ -182,6 +187,7 @@ internal class C3Connection(override val variant: CaosVariant, private val data:
      * Inject caos code into CV+ games
      */
     override fun injectEventScript(
+        project: Project,
         fileName: String,
         family: Int,
         genus: Int,

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/CreateInjectorDialog.form
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/CreateInjectorDialog.form
@@ -4,12 +4,12 @@
     <rowspec value="center:d:grow"/>
     <colspec value="fill:d:grow"/>
     <constraints>
-      <xy x="48" y="54" width="761" height="267"/>
+      <xy x="48" y="54" width="761" height="269"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="71b37" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="71b37" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -67,7 +67,7 @@
           </component>
           <component id="97bb7" class="javax.swing.JLabel" binding="gameNameLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <labelFor value="e831"/>
@@ -76,7 +76,7 @@
           </component>
           <component id="e831" class="javax.swing.JTextField" binding="gameName">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -84,7 +84,7 @@
           </component>
           <component id="2141f" class="javax.swing.JLabel" binding="gameFolderLabel">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <labelFor value="86733"/>
@@ -93,7 +93,7 @@
           </component>
           <component id="86733" class="javax.swing.JTextField" binding="gameFolder" custom-create="true">
             <constraints>
-              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -118,7 +118,7 @@
           </component>
           <component id="39bb3" class="javax.swing.JLabel" binding="urlHelpText">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="com/badahori/creatures/plugins/intellij/caos-bundle" key="caos.injector.dialog.url.help"/>
@@ -140,6 +140,22 @@
               </grid>
             </constraints>
             <properties/>
+          </component>
+          <component id="862bf" class="javax.swing.JTextField" binding="wineExecutable" custom-create="true">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="b40a2" class="javax.swing.JLabel" binding="wineExecutableLabel">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Wine Binary"/>
+            </properties>
           </component>
         </children>
       </grid>

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/DDEConnection.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/DDEConnection.kt
@@ -21,7 +21,11 @@ internal class DDEConnection(override val variant: CaosVariant, private val data
     override val supportsJect: Boolean
         get() = false
 
-    override fun injectWithJect(caos: CaosScriptFile, flags: Int): InjectionStatus {
+    override fun injectWithJect(
+        project: Project,
+        caos: CaosScriptFile,
+        flags: Int
+    ): InjectionStatus {
         return InjectionStatus.ActionNotSupported(
             caos.name,
             null,
@@ -38,7 +42,12 @@ internal class DDEConnection(override val variant: CaosVariant, private val data
             }
         } ?: VIVARIUM
 
-    override fun inject(fileName: String, descriptor: String?, caos: String): InjectionStatus {
+    override fun inject(
+        project: Project,
+        fileName: String,
+        descriptor: String?,
+        caos: String
+    ): InjectionStatus {
         if (!OsUtil.isWindows) {
             return NOT_WINDOWS_STATUS
         }
@@ -83,6 +92,7 @@ internal class DDEConnection(override val variant: CaosVariant, private val data
     }
 
     override fun injectEventScript(
+        project: Project,
         fileName: String,
         family: Int,
         genus: Int,
@@ -101,7 +111,7 @@ internal class DDEConnection(override val variant: CaosVariant, private val data
         } else {
             caos
         }
-        return inject(fileName, "scrp $family $genus $species $eventNumber", caosFormatted)
+        return inject(project, fileName, "scrp $family $genus $species $eventNumber", caosFormatted)
     }
 
     override fun disconnect(): Boolean {

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/GameInterfaceName.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/GameInterfaceName.kt
@@ -19,6 +19,7 @@ sealed class GameInterfaceName {
     abstract val path: String?
     abstract val kind: String
     protected abstract val nickname: String?
+    open val tail: String? = null
 
     open val name: String get()  {
         val code = if (code == "AL" || code == "ANY") {
@@ -85,7 +86,7 @@ sealed class GameInterfaceName {
     protected abstract fun asSerial(): String
 
     companion object {
-        private val BASIC_REGEX = "([^:]+\\s*):\\s*([^\\[]+)\\s*(?:\\[\\s*([^\\]]+)](:.*)?\\s*)?".toRegex()
+        private val BASIC_REGEX = "([^:]+\\s*):\\s*([^\\[]+)\\s*(?:\\[\\s*([^\\]]+)])?\\s*(:.*?)?\\s*".toRegex()
         private const val TYPE_DELIMITER = "__;;;;;;;;;;__"
         private const val GAME_NAME_PATH_DELIMITER = "<__;;x;;;;;;x;;__>"
         internal const val ADDITIONAL_DATA_DELIMITER = "##__xx__##"
@@ -174,7 +175,9 @@ sealed class GameInterfaceName {
         internal fun defaultComponents(data: String): DefaultComponents? {
             val parts = BASIC_REGEX.matchEntire(data)
                 ?.groupValues
-                ?: return null
+                ?: return null.also {
+                    LOGGER.info("Failed to parse Injector interface string: <$data>")
+                }
             val code = parts[1]
                 .trim()
                 .nullIfEmpty()

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/GameInterfaceName.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/GameInterfaceName.kt
@@ -1,12 +1,13 @@
 package com.badahori.creatures.plugins.intellij.agenteering.injector
 
-import com.bedalton.common.util.OS
 import com.badahori.creatures.plugins.intellij.agenteering.caos.lang.CaosBundle.message
 import com.badahori.creatures.plugins.intellij.agenteering.caos.libs.CaosVariant
 import com.badahori.creatures.plugins.intellij.agenteering.caos.libs.injectorInterfaceName
 import com.badahori.creatures.plugins.intellij.agenteering.caos.libs.nullIfUnknown
 import com.badahori.creatures.plugins.intellij.agenteering.utils.LOGGER
 import com.badahori.creatures.plugins.intellij.agenteering.utils.nullIfEmpty
+import com.bedalton.common.util.OS
+import kotlinx.serialization.Serializable
 import java.net.URL
 
 /**
@@ -84,7 +85,7 @@ sealed class GameInterfaceName {
     protected abstract fun asSerial(): String
 
     companion object {
-        private val BASIC_REGEX = "([^:]+\\s*):\\s*([^\\[]+)\\s*(?:\\[\\s*([^\\]]+)]\\s*)?".toRegex()
+        private val BASIC_REGEX = "([^:]+\\s*):\\s*([^\\[]+)\\s*(?:\\[\\s*([^\\]]+)](:.*)?\\s*)?".toRegex()
         private const val TYPE_DELIMITER = "__;;;;;;;;;;__"
         private const val GAME_NAME_PATH_DELIMITER = "<__;;x;;;;;;x;;__>"
         internal const val ADDITIONAL_DATA_DELIMITER = "##__xx__##"
@@ -184,9 +185,13 @@ sealed class GameInterfaceName {
             val nickname = parts.getOrNull(3)
                 ?.trim()
                 ?.nullIfEmpty()
+            val tail = parts.getOrNull(4)
+                ?.nullIfEmpty()
+                ?.substring(1)
+                ?.trim()
             val gameName = pathParts[0].trim().let { if (it == NULL) null else it }
             val path = pathParts.getOrNull(1)?.trim().let { if (it == NULL) null else it }
-            return DefaultComponents(code, gameName, path, nickname)
+            return DefaultComponents(code, gameName, path, nickname, tail)
         }
 
         internal fun defaultSerial(
@@ -194,6 +199,7 @@ sealed class GameInterfaceName {
             gameName: String?,
             path: String?,
             nickname: String?,
+            tail: String? = null
         ): String {
             val combinedPath = (gameName ?: NULL) + (path?.let { GAME_NAME_PATH_DELIMITER + it } ?: "")
             val builder = StringBuilder()
@@ -201,6 +207,9 @@ sealed class GameInterfaceName {
             builder.append(combinedPath)
             if (nickname != null) {
                 builder.append('[').append(nickname).append(']')
+            }
+            if (tail != null) {
+                builder.append(':').append(tail)
             }
             return builder.toString()
         }
@@ -255,12 +264,14 @@ data class NativeInjectorInterface constructor(
     }
 }
 
+@Serializable
 data class WineInjectorInterface constructor(
     override val code: String,
     override val gameName: String?,
     val prefix: String,
     val creaturesDirectory: String?,
     override val nickname: String?,
+    val wineExecutable: String?
 ) : GameInterfaceName() {
 
     override val kind get() = KIND
@@ -270,7 +281,7 @@ data class WineInjectorInterface constructor(
         get() = prefix
 
     override fun asSerial(): String {
-        return prefix + DELIMITER + defaultSerial(code, gameName, creaturesDirectory, nickname)
+        return prefix + DELIMITER + defaultSerial(code, gameName, creaturesDirectory, nickname, wineExecutable)
     }
 
     override fun withCode(code: String): GameInterfaceName {
@@ -286,14 +297,15 @@ data class WineInjectorInterface constructor(
             val prefix = parts[0]
             val data = parts.getOrNull(1)
                 ?: return null
-            val (code, gameName, creaturesDirectory, nickname) = defaultComponents(data)
+            val (code, gameName, creaturesDirectory, nickname, tail) = defaultComponents(data)
                 ?: return null
             return WineInjectorInterface(
                 code = code,
                 gameName = gameName,
                 prefix = prefix,
                 creaturesDirectory = creaturesDirectory,
-                nickname = nickname
+                nickname = nickname,
+                wineExecutable = tail
             )
         }
 
@@ -560,4 +572,5 @@ internal data class DefaultComponents(
     val gameName: String?,
     val path: String?,
     val nickName: String?,
+    val tail: String? = null
 )

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/Injector.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/Injector.kt
@@ -46,7 +46,7 @@ object Injector {
 
         val response =
             injectPrivateSafe(project, fallbackVariant, gameInterfaceName, "$$\$private$$$", false) { connection ->
-                connection.inject("$$\$private$$$", null, rawCode)
+                connection.inject(project, "$$\$private$$$", null, rawCode)
             } ?: return fallbackVariant
 
         if (response !is InjectionStatus.Ok) {
@@ -349,9 +349,10 @@ internal interface CaosConnection {
     val variant: CaosVariant
 
     val supportsJect: Boolean
-    fun inject(fileName: String, descriptor: String?, caos: String): InjectionStatus
-    fun injectWithJect(caos: CaosScriptFile, flags: Int): InjectionStatus
+    fun inject(project: Project, fileName: String, descriptor: String?, caos: String): InjectionStatus
+    fun injectWithJect(project: Project, caos: CaosScriptFile, flags: Int): InjectionStatus
     fun injectEventScript(
+        project: Project,
         fileName: String,
         family: Int,
         genus: Int,

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/PostConnection.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/PostConnection.kt
@@ -27,7 +27,12 @@ internal class PostConnection(override val variant: CaosVariant, private val gam
         gameInterfaceName.getURL(variant)
     }
 
-    override fun inject(fileName: String, descriptor: String?, caos: String): InjectionStatus {
+    override fun inject(
+        project: Project,
+        fileName: String,
+        descriptor: String?,
+        caos: String
+    ): InjectionStatus {
         val url = url
             ?: return InjectionStatus.BadConnection(
                 fileName,
@@ -110,7 +115,7 @@ internal class PostConnection(override val variant: CaosVariant, private val gam
         }
     }
 
-    override fun injectWithJect(caos: CaosScriptFile, flags: Int): InjectionStatus {
+    override fun injectWithJect(project: Project, caos: CaosScriptFile, flags: Int): InjectionStatus {
         return InjectionStatus.ActionNotSupported(
             caos.name,
             null,
@@ -119,6 +124,7 @@ internal class PostConnection(override val variant: CaosVariant, private val gam
     }
 
     override fun injectEventScript(
+        project: Project,
         fileName: String,
         family: Int,
         genus: Int,
@@ -141,7 +147,7 @@ internal class PostConnection(override val variant: CaosVariant, private val gam
             "$expectedHeader $stripped"
         } else
             caos
-        return inject(fileName, "scrp $family $genus $species $eventNumber", caosFormatted)
+        return inject(project, fileName, "scrp $family $genus $species $eventNumber", caosFormatted)
     }
 
     override fun disconnect(): Boolean = true

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/TCPConnection.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/TCPConnection.kt
@@ -23,7 +23,12 @@ internal class TCPConnection(override val variant: CaosVariant, private val game
         gameInterfaceName.getURL(variant)
     }
 
-    override fun inject(fileName: String, descriptor: String?, caos: String): InjectionStatus {
+    override fun inject(
+        project: Project,
+        fileName: String,
+        descriptor: String?,
+        caos: String
+    ): InjectionStatus {
 //        val url = url
 //            ?: return InjectionStatus.BadConnection("Invalid URL for POST http connection")
         return InjectionStatus.ActionNotSupported(
@@ -33,7 +38,7 @@ internal class TCPConnection(override val variant: CaosVariant, private val game
         )
     }
 
-    override fun injectWithJect(caos: CaosScriptFile, flags: Int): InjectionStatus {
+    override fun injectWithJect(project: Project, caos: CaosScriptFile, flags: Int): InjectionStatus {
         return InjectionStatus.ActionNotSupported(
             caos.name,
             null,
@@ -42,6 +47,7 @@ internal class TCPConnection(override val variant: CaosVariant, private val game
     }
 
     override fun injectEventScript(
+        project: Project,
         fileName: String,
         family: Int,
         genus: Int,
@@ -75,7 +81,7 @@ internal class TCPConnection(override val variant: CaosVariant, private val game
         } else {
             caos
         }
-        return inject(fileName, descriptor, caosFormatted)
+        return inject(project, fileName, descriptor, caosFormatted)
     }
 
     override fun disconnect(): Boolean = true

--- a/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/WineExecutableSelector.kt
+++ b/src/main/java/com/badahori/creatures/plugins/intellij/agenteering/injector/WineExecutableSelector.kt
@@ -1,0 +1,60 @@
+package com.badahori.creatures.plugins.intellij.agenteering.injector
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogBuilder
+import com.intellij.openapi.ui.TextComponentAccessor
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import java.awt.Component
+import javax.swing.*
+
+object WineExecutableSelector {
+    private val RECENTS_KEY = "com.badahori.creatures.plugins.intellij.agenteering.injector.RECENT_WINE_FOLDERS"
+
+    fun create(
+        project: Project,
+        initialLocation: String,
+        isWin32: Boolean,
+        folderChangeListener: (path: String?) -> Unit
+    ): DialogBuilder {
+        val wine = if (isWin32) "Wine 32" else "Wine 64"
+        val browseButton = TextFieldWithBrowseButton().apply {
+            this.alignmentX = Component.LEFT_ALIGNMENT
+            this.addBrowseFolderListener(
+                "Choose $wine Executable",
+                "Choose the wine executable which is running Creatures",
+                project,
+                FileChooserDescriptor(
+                    false,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false
+                ),
+                TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT
+            )
+            this.textField.text = initialLocation
+        }
+
+        return object : DialogBuilder() {
+            override fun setOkOperation(runnable: Runnable?) {
+                super.setOkOperation {
+                    folderChangeListener(browseButton.textField.text)
+                    runnable?.run()
+                    this.dialogWrapper.close(0)
+                }
+            }
+        }.apply {
+            setCenterPanel(JPanel().apply {
+                this.layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                this.alignmentX = Component.LEFT_ALIGNMENT
+                this.add(JLabel("Choose $wine Executable").apply {
+                    this.alignmentX = Component.LEFT_ALIGNMENT
+                })
+                this.add(browseButton)
+            })
+            setOkOperation(null)
+        }
+    }
+}


### PR DESCRIPTION
On macOS Ventura, the wine executable path could not longer be automatically found.
This commit adds the ability to manually specify the WINE binary location.

Fixes #26